### PR TITLE
style(AboutContent): change padding top for mobile

### DIFF
--- a/src/components/organisms/AboutContent.jsx
+++ b/src/components/organisms/AboutContent.jsx
@@ -33,7 +33,7 @@ const styles = StyleSheet.create({
   },
   containerMobile: {
     paddingHorizontal: 20,
-    paddingTop: 265,
+    paddingTop: 60,
     gap: 60,
   },
 });


### PR DESCRIPTION
### Description
change the padding top of the about content for mobile responsive because we deleted the floating image